### PR TITLE
Use calendar locale for tooltip times, translate remaining strings

### DIFF
--- a/public/js/tippy.js
+++ b/public/js/tippy.js
@@ -23,12 +23,28 @@ function hycal_tippyRender(info, currCal, hycalSettings) {
     }
   }
 
+  // Format times with the calendar's locale rather than the visitor's browser,
+  // so a de calendar reads 14:30 for every visitor. The locale arrives from a
+  // shortcode attribute, so an unrecognized tag would throw here; an empty
+  // array falls back to the browser default.
+  let timeLocale = [];
+  try {
+    timeLocale = Intl.DateTimeFormat.supportedLocalesOf(
+      (hycalSettings && hycalSettings["locale"]) || [],
+    );
+  } catch (e) {
+    timeLocale = [];
+  }
+
+  const formatTime = (dateStr) =>
+    new Date(dateStr).toLocaleTimeString(timeLocale, {
+      hour: "numeric",
+      minute: "2-digit",
+    });
+
   const startTime = info.event.allDay
-    ? "All Day"
-    : new Date(info.event.startStr).toLocaleTimeString([], {
-        hour: "numeric",
-        minute: "2-digit",
-      });
+    ? wp.i18n.__("All Day", "hydrogen-calendar-embeds")
+    : formatTime(info.event.startStr);
 
   // Check if displayEventEnd is disabled via fc_args
   let displayEventEnd = true;
@@ -46,11 +62,7 @@ function hycal_tippyRender(info, currCal, hycalSettings) {
   const endTime =
     !displayEventEnd || info.event.allDay
       ? ""
-      : " - " +
-        new Date(info.event.endStr).toLocaleTimeString([], {
-          hour: "numeric",
-          minute: "2-digit",
-        });
+      : " - " + formatTime(info.event.endStr);
 
   const location = info.event.extendedProps.location || "";
 
@@ -82,7 +94,7 @@ function hycal_tippyRender(info, currCal, hycalSettings) {
   let headerHtml = hycalHooks.applyFilters(
     "hycal.tooltipHeader",
     `
-    <button class="hycal-tooltip-close" aria-label="Close" type="button" style="position: absolute; top: 8px; right: 8px; background: none; border: none; font-size: 24px; cursor: pointer; padding: 0; line-height: 1; color: inherit; opacity: 0.7;">
+    <button class="hycal-tooltip-close" aria-label="${wp.i18n.__("Close", "hydrogen-calendar-embeds")}" type="button" style="position: absolute; top: 8px; right: 8px; background: none; border: none; font-size: 24px; cursor: pointer; padding: 0; line-height: 1; color: inherit; opacity: 0.7;">
       <span aria-hidden="true">&times;</span>
     </button>
     <h2 class="hycal-event-title">${eventTitle} </h2>


### PR DESCRIPTION
Two small localization bugs in the event tooltip, both in `public/js/tippy.js`.

### Tooltip times ignore the `locale` setting

`hycal_tippyRender()` formatted times with `toLocaleTimeString([], …)`. The empty array means "use the browser's default locale", so the tooltip ignored the calendar's `locale` and followed each visitor's browser instead. A `locale="de"` calendar still showed `2:30 PM` to a visitor with an en-US browser, and the same page rendered `14:30` for a visitor with a German one.

`hycalSettings` is already passed into the function (it's read a few lines below for `fc_args`), so the configured locale was in scope already.

The tag is resolved through `Intl.DateTimeFormat.supportedLocalesOf()` rather than passed straight to `toLocaleTimeString()`. Since `locale` can come from a shortcode attribute it's arbitrary text, and a plausible typo like `de_DE` throws a `RangeError` — that would have taken out the whole tooltip. Anything unrecognized now falls back to the previous browser-default behavior.

I kept `hour: "numeric"` rather than switching to `"2-digit"`: it would give German the zero-padded `09:05` that's conventional there, but it also turns English into `02:30 PM`, which seemed like a bad trade. Happy to change it if you'd prefer padding.

### Two strings weren't translatable

`"All Day"` and the close button's `aria-label="Close"` were bare literals, so they stayed English regardless of site language — unlike `"Busy"` in the same function. Both are now wrapped in `wp.i18n.__()` with the `hydrogen-calendar-embeds` text domain.

### Notes

`public/js/tippy.js` is enqueued directly rather than bundled into the block, so no `npm run build` is needed.

Verified `node --check` and the locale resolution across inputs (`de` → `14:30`, `en` → `2:30 PM`, `en-gb` → `14:30`, `sr-cyrl` → normalizes to `sr-Cyrl`, `de_DE` → falls back). I have not exercised this in a live WordPress install, so a check against a real calendar is worth doing before merge. I also couldn't run `npm run lint:js` as I didn't have `node_modules` installed locally.